### PR TITLE
add index matching of filter to index scan rule

### DIFF
--- a/cso-core/src/expression.rs
+++ b/cso-core/src/expression.rs
@@ -12,6 +12,8 @@ pub trait ScalarExpression: AsAny + Debug + Clone {
     fn equal(&self, other: &dyn ScalarExpression) -> bool;
 
     fn derive_used_columns(&self, col_set: &mut ColumnRefSet);
+
+    fn split_predicates(&self) -> Vec<Box<dyn ScalarExpression>>;
 }
 
 impl dyn ScalarExpression {

--- a/src/expression/cmp.rs
+++ b/src/expression/cmp.rs
@@ -37,6 +37,13 @@ impl ScalarExpression for Equal {
         self.left.derive_used_columns(col_set);
         self.right.derive_used_columns(col_set);
     }
+
+    fn split_predicates(&self) -> Vec<Box<dyn ScalarExpression>> {
+        let mut expressions = Vec::new();
+        expressions.push(self.left.clone());
+        expressions.push(self.right.clone());
+        expressions
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -74,6 +81,13 @@ impl ScalarExpression for NotEqual {
     fn derive_used_columns(&self, col_set: &mut ColumnRefSet) {
         self.left.derive_used_columns(col_set);
         self.right.derive_used_columns(col_set);
+    }
+
+    fn split_predicates(&self) -> Vec<Box<dyn ScalarExpression>> {
+        let mut expressions = Vec::new();
+        expressions.push(self.left.clone());
+        expressions.push(self.right.clone());
+        expressions
     }
 }
 
@@ -113,6 +127,13 @@ impl ScalarExpression for GreaterThan {
         self.left.derive_used_columns(col_set);
         self.right.derive_used_columns(col_set);
     }
+
+    fn split_predicates(&self) -> Vec<Box<dyn ScalarExpression>> {
+        let mut expressions = Vec::new();
+        expressions.push(self.left.clone());
+        expressions.push(self.right.clone());
+        expressions
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -150,6 +171,13 @@ impl ScalarExpression for LessThan {
     fn derive_used_columns(&self, col_set: &mut ColumnRefSet) {
         self.left.derive_used_columns(col_set);
         self.right.derive_used_columns(col_set);
+    }
+
+    fn split_predicates(&self) -> Vec<Box<dyn ScalarExpression>> {
+        let mut expressions = Vec::new();
+        expressions.push(self.left.clone());
+        expressions.push(self.right.clone());
+        expressions
     }
 }
 
@@ -189,6 +217,13 @@ impl ScalarExpression for GreaterThanEqual {
         self.left.derive_used_columns(col_set);
         self.right.derive_used_columns(col_set);
     }
+
+    fn split_predicates(&self) -> Vec<Box<dyn ScalarExpression>> {
+        let mut expressions = Vec::new();
+        expressions.push(self.left.clone());
+        expressions.push(self.right.clone());
+        expressions
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -226,5 +261,12 @@ impl ScalarExpression for LessThanEqual {
     fn derive_used_columns(&self, col_set: &mut ColumnRefSet) {
         self.left.derive_used_columns(col_set);
         self.right.derive_used_columns(col_set);
+    }
+
+    fn split_predicates(&self) -> Vec<Box<dyn ScalarExpression>> {
+        let mut expressions = Vec::new();
+        expressions.push(self.left.clone());
+        expressions.push(self.right.clone());
+        expressions
     }
 }

--- a/src/expression/const.rs
+++ b/src/expression/const.rs
@@ -19,4 +19,8 @@ impl ScalarExpression for Const {
     fn derive_used_columns(&self, _col_set: &mut ColumnRefSet) {
         // no column
     }
+
+    fn split_predicates(&self) -> Vec<Box<dyn ScalarExpression>> {
+        Vec::new()
+    }
 }

--- a/src/expression/is_null.rs
+++ b/src/expression/is_null.rs
@@ -27,6 +27,12 @@ impl ScalarExpression for IsNull {
     fn derive_used_columns(&self, col_set: &mut ColumnRefSet) {
         self.inner.derive_used_columns(col_set);
     }
+
+    fn split_predicates(&self) -> Vec<Box<dyn ScalarExpression>> {
+        let mut expressions = Vec::new();
+        expressions.push(self.inner.clone());
+        expressions
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -54,5 +60,11 @@ impl ScalarExpression for IsNotNull {
 
     fn derive_used_columns(&self, col_set: &mut ColumnRefSet) {
         self.inner.derive_used_columns(col_set);
+    }
+
+    fn split_predicates(&self) -> Vec<Box<dyn ScalarExpression>> {
+        let mut expressions = Vec::new();
+        expressions.push(self.inner.clone());
+        expressions
     }
 }

--- a/src/expression/logical.rs
+++ b/src/expression/logical.rs
@@ -24,6 +24,14 @@ impl ScalarExpression for And {
     fn derive_used_columns(&self, col_set: &mut ColumnRefSet) {
         self.expressions.iter().for_each(|e| e.derive_used_columns(col_set));
     }
+
+    fn split_predicates(&self) -> Vec<Box<dyn ScalarExpression>> {
+        let mut predicates = Vec::new();
+        self.expressions
+            .iter()
+            .for_each(|e| predicates.extend(e.split_predicates()));
+        predicates
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -49,6 +57,12 @@ impl ScalarExpression for Or {
     fn derive_used_columns(&self, col_set: &mut ColumnRefSet) {
         self.expressions.iter().for_each(|e| e.derive_used_columns(col_set));
     }
+
+    fn split_predicates(&self) -> Vec<Box<dyn ScalarExpression>> {
+        let mut expressions = Vec::new();
+        expressions.extend(self.expressions.clone());
+        expressions
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -73,5 +87,11 @@ impl ScalarExpression for Not {
 
     fn derive_used_columns(&self, col_set: &mut ColumnRefSet) {
         self.expression.derive_used_columns(col_set);
+    }
+
+    fn split_predicates(&self) -> Vec<Box<dyn ScalarExpression>> {
+        let mut expressions = Vec::new();
+        expressions.push(self.expression.clone());
+        expressions
     }
 }

--- a/src/expression/var.rs
+++ b/src/expression/var.rs
@@ -28,4 +28,8 @@ impl ScalarExpression for ColumnVar {
     fn derive_used_columns(&self, col_set: &mut ColumnRefSet) {
         col_set.insert(self.id);
     }
+
+    fn split_predicates(&self) -> Vec<Box<dyn ScalarExpression>> {
+        Vec::new()
+    }
 }

--- a/src/rule/exploration/filter_2_index_scan.rs
+++ b/src/rule/exploration/filter_2_index_scan.rs
@@ -1,3 +1,4 @@
+use crate::expression::And;
 use crate::operator::logical_filter::LogicalFilter;
 use crate::operator::logical_index_scan::LogicalIndexScan;
 use crate::operator::logical_scan::LogicalScan;
@@ -8,6 +9,7 @@ use crate::{Demo, OptimizerContext, Pattern, Plan};
 use cso_core::expression::ScalarExpression;
 use cso_core::operator::Operator;
 use cso_core::rule::{PatternType, Rule};
+use cso_core::ColumnRefSet;
 use std::rc::Rc;
 
 pub struct Filter2IndexScan {
@@ -76,8 +78,7 @@ impl Rule<Demo> for Filter2IndexScan {
                 );
                 let mut new_plan = Plan::new(Operator::Logical(Rc::new(logical_index_scan)), vec![], None);
 
-                if let Some(residual_predicate) = residual_predicate {
-                    let new_logical_filter = LogicalFilter::new(residual_predicate);
+                if let Some(new_logical_filter) = residual_predicate {
                     new_plan = Plan::new(Operator::Logical(Rc::new(new_logical_filter)), vec![new_plan], None);
                 }
 
@@ -92,7 +93,34 @@ impl Rule<Demo> for Filter2IndexScan {
     }
 }
 
-fn index_matched(_index_md: &IndexMd, _predicate: &dyn ScalarExpression) -> (bool, Option<Rc<dyn ScalarExpression>>) {
-    // todo!()
-    (true, None)
+fn index_matched(index_md: &IndexMd, predicate: &dyn ScalarExpression) -> (bool, Option<LogicalFilter>) {
+    let mut predicate_include_columns = ColumnRefSet::new();
+    predicate.derive_used_columns(&mut predicate_include_columns);
+    let mut index_include_columns = ColumnRefSet::new();
+    for index_key in index_md.included_columns() {
+        index_key.derive_used_columns(&mut index_include_columns);
+    }
+    // index type is only btree now, so no need to judge
+    if predicate_include_columns.is_superset(&index_include_columns) {
+        (true, None)
+    } else {
+        // split predicates into index part and not index part
+        let mut residual_predicate = Vec::new();
+        let mut applicable = false;
+        for expression in predicate.split_predicates() {
+            let mut predicate_include_columns = ColumnRefSet::new();
+            expression.derive_used_columns(&mut predicate_include_columns);
+            if index_include_columns.is_disjoint(&predicate_include_columns) {
+                residual_predicate.push(expression);
+            } else {
+                applicable = true;
+            }
+        }
+        if applicable {
+            let new_logical_filter = LogicalFilter::new(Rc::new(And::new(residual_predicate)));
+            (applicable, Some(new_logical_filter))
+        } else {
+            (false, None)
+        }
+    }
 }

--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -1,4 +1,5 @@
 use crate::datum::Datum;
+use crate::expression::ColumnVar;
 use cso_core::metadata::Metadata;
 use cso_core::metadata::Stats;
 use serde::{Deserialize, Serialize};
@@ -292,8 +293,8 @@ pub struct IndexMd {
     mdid: u64,
     index_name: String,
     index_type: IndexType,
-    key_columns: Vec<usize>,
-    included_columns: Vec<usize>,
+    key_columns: Vec<ColumnVar>,
+    included_columns: Vec<ColumnVar>,
 }
 
 impl IndexMd {
@@ -317,6 +318,14 @@ impl IndexMd {
 
     pub fn index_type(&self) -> &IndexType {
         &self.index_type
+    }
+
+    pub fn key_columns(&self) -> &Vec<ColumnVar> {
+        &self.key_columns
+    }
+
+    pub fn included_columns(&self) -> &Vec<ColumnVar> {
+        &self.included_columns
     }
 }
 


### PR DESCRIPTION
when we have a tree like:

filter(a = 1 and b = 2) 
-- tablescan(index on a)

we will generate tree like:

filter(b = 2)
-- indexscan(a = 1 and b = 2)
